### PR TITLE
Dc postfix repetition sugar

### DIFF
--- a/Madness/Parser.swift
+++ b/Madness/Parser.swift
@@ -102,6 +102,11 @@ public postfix func * <T> (parser: Parser<T>.Function) -> Parser<[T]>.Function {
 	return repeat(parser)
 }
 
+/// Creates a parser from `string`, and parses it 0 or more times.
+public postfix func * (string: String) -> Parser<[String]>.Function {
+	return repeat(%(string))
+}
+
 /// Parses `parser` 0 or more times and drops its parse trees.
 public postfix func * (parser: Parser<()>.Function) -> Parser<()>.Function {
 	return repeat(parser) --> const(())
@@ -110,6 +115,11 @@ public postfix func * (parser: Parser<()>.Function) -> Parser<()>.Function {
 /// Parses `parser` 1 or more times.
 public postfix func + <T> (parser: Parser<T>.Function) -> Parser<[T]>.Function {
 	return repeat(parser, 1..<Int.max)
+}
+
+/// Creates a parser from `string`, and parses it 1 or more times.
+public postfix func + (string: String) -> Parser<[String]>.Function {
+	return repeat(%(string), 1..<Int.max)
 }
 
 /// Parses `parser` 0 or more times and drops its parse trees.

--- a/MadnessTests/ParserTests.swift
+++ b/MadnessTests/ParserTests.swift
@@ -193,7 +193,51 @@ final class ParserTests: XCTestCase {
 	func testMToNRepetitionMatchesUpToN() {
 		assertEqual(mToN("xxxx")?.1, "x")
 	}
-
+	
+	
+	// MARK: Repetition shorthand
+	let zeroOrMoreSimple = "x"*
+	
+	func testZeroOrMoreSimpleRepetitionAcceptsTheEmptyString() {
+		assertNotNil(zeroOrMoreSimple(""))
+	}
+	
+	func testZeroOrMoreSimpleRepetitionAcceptsUnmatchedStrings() {
+		assertNotNil(zeroOrMoreSimple("y"))
+	}
+	
+	func testZeroOrMoreSimpleRepetitionDoesNotAdvanceWithUnmatchedStrings() {
+		assertEqual(zeroOrMoreSimple("y")?.1, "y")
+	}
+	
+	func testZeroOrMoreSimpleRepetitionParsesUnmatchedStringsAsEmptyArrays() {
+		assertEqual(zeroOrMoreSimple("y")?.0, [])
+	}
+	
+	func testZeroOrMoreSimpleRepetitionParsesAMatchedString() {
+		assertEqual(zeroOrMoreSimple("x")?.0, ["x"])
+	}
+	
+	func testZeroOrMoreSimpleRepetitionParsesMatchedStrings() {
+		assertEqual(zeroOrMoreSimple("xx")?.0, ["x", "x"])
+	}
+	
+	
+	let oneOrMoreSimple = "x"+
+	
+	func testOneOrMoreSimpleRepetitionRejectsTheEmptyString() {
+		assertNil(oneOrMoreSimple(""))
+	}
+	
+	func testOneOrMoreSimpleRepetitionParsesASingleMatchedString() {
+		assertEqual(oneOrMoreSimple("x")?.0, ["x"])
+	}
+	
+	func testOneOrMoreSimpleRepetitonParsesMultipleMatchedStrings() {
+		assertEqual(oneOrMoreSimple("xxy")?.0, ["x", "x"])
+	}
+	
+	
 
 	// MARK: Ignoring
 


### PR DESCRIPTION
For issue #53: I’ve implemented the + and * postfix operators for strings, as well as tests for them. Do you want implementations for the other literals? Or maybe Either?