### PR TITLE
Provide the parsed range to reductions

### DIFF
--- a/Madness.xcodeproj/project.pbxproj
+++ b/Madness.xcodeproj/project.pbxproj
@@ -13,6 +13,8 @@
 		D421A2AA1A9A8E33009AC3B1 /* IgnoreTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D421A2A81A9A8E33009AC3B1 /* IgnoreTests.swift */; };
 		D421A2AC1A9A9540009AC3B1 /* ReductionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D421A2AB1A9A9540009AC3B1 /* ReductionTests.swift */; };
 		D421A2AD1A9A9540009AC3B1 /* ReductionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D421A2AB1A9A9540009AC3B1 /* ReductionTests.swift */; };
+		D47B10761A9A9A1C006701A8 /* Reduction.swift in Sources */ = {isa = PBXBuildFile; fileRef = D47B10751A9A9A1C006701A8 /* Reduction.swift */; };
+		D47B10771A9A9A1C006701A8 /* Reduction.swift in Sources */ = {isa = PBXBuildFile; fileRef = D47B10751A9A9A1C006701A8 /* Reduction.swift */; };
 		D490927A1A98F11A00275C79 /* CollectionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D49092791A98F11A00275C79 /* CollectionTests.swift */; };
 		D490927B1A98F11A00275C79 /* CollectionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D49092791A98F11A00275C79 /* CollectionTests.swift */; };
 		D4BC5E021A98C8B4008C6851 /* Madness.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = D4BC5DF71A98C8B4008C6851 /* Madness.framework */; };
@@ -76,6 +78,7 @@
 		D421A2A51A9A8DD4009AC3B1 /* Ignore.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Ignore.swift; sourceTree = "<group>"; };
 		D421A2A81A9A8E33009AC3B1 /* IgnoreTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = IgnoreTests.swift; sourceTree = "<group>"; };
 		D421A2AB1A9A9540009AC3B1 /* ReductionTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = ReductionTests.swift; path = MadnessTests/ReductionTests.swift; sourceTree = SOURCE_ROOT; };
+		D47B10751A9A9A1C006701A8 /* Reduction.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Reduction.swift; sourceTree = "<group>"; };
 		D49092791A98F11A00275C79 /* CollectionTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = CollectionTests.swift; sourceTree = "<group>"; };
 		D4BC5DF71A98C8B4008C6851 /* Madness.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Madness.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		D4BC5E011A98C8B4008C6851 /* Madness-iOSTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = "Madness-iOSTests.xctest"; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -174,9 +177,10 @@
 				D4FC47B61A37E47C00D23A6F /* Madness.h */,
 				D4FC47CD1A37E48800D23A6F /* Parser.swift */,
 				D4C2EDAD1A98D52B00054FAA /* Alternation.swift */,
+				D4C2EDA61A98D38E00054FAA /* Concatenation.swift */,
 				D4C2EDBB1A98D8F800054FAA /* FlatMap.swift */,
 				D421A2A51A9A8DD4009AC3B1 /* Ignore.swift */,
-				D4C2EDA61A98D38E00054FAA /* Concatenation.swift */,
+				D47B10751A9A9A1C006701A8 /* Reduction.swift */,
 				D4C2EDB31A98D63600054FAA /* Repetition.swift */,
 				D4FC47B41A37E47C00D23A6F /* Supporting Files */,
 			);
@@ -396,6 +400,7 @@
 				D4BC5E101A98C978008C6851 /* Parser.swift in Sources */,
 				D4C2EDBD1A98D8F800054FAA /* FlatMap.swift in Sources */,
 				D4C2EDAC1A98D4DE00054FAA /* Concatenation.swift in Sources */,
+				D47B10771A9A9A1C006701A8 /* Reduction.swift in Sources */,
 				D421A2A71A9A8DD4009AC3B1 /* Ignore.swift in Sources */,
 				D4C2EDB61A98D65300054FAA /* Repetition.swift in Sources */,
 			);
@@ -424,6 +429,7 @@
 				D4FC47CE1A37E48800D23A6F /* Parser.swift in Sources */,
 				D4C2EDBC1A98D8F800054FAA /* FlatMap.swift in Sources */,
 				D4C2EDA71A98D38E00054FAA /* Concatenation.swift in Sources */,
+				D47B10761A9A9A1C006701A8 /* Reduction.swift in Sources */,
 				D421A2A61A9A8DD4009AC3B1 /* Ignore.swift in Sources */,
 				D4C2EDB71A98D65400054FAA /* Repetition.swift in Sources */,
 			);

--- a/Madness.xcodeproj/project.pbxproj
+++ b/Madness.xcodeproj/project.pbxproj
@@ -11,6 +11,8 @@
 		D421A2A71A9A8DD4009AC3B1 /* Ignore.swift in Sources */ = {isa = PBXBuildFile; fileRef = D421A2A51A9A8DD4009AC3B1 /* Ignore.swift */; };
 		D421A2A91A9A8E33009AC3B1 /* IgnoreTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D421A2A81A9A8E33009AC3B1 /* IgnoreTests.swift */; };
 		D421A2AA1A9A8E33009AC3B1 /* IgnoreTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D421A2A81A9A8E33009AC3B1 /* IgnoreTests.swift */; };
+		D421A2AC1A9A9540009AC3B1 /* ReductionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D421A2AB1A9A9540009AC3B1 /* ReductionTests.swift */; };
+		D421A2AD1A9A9540009AC3B1 /* ReductionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D421A2AB1A9A9540009AC3B1 /* ReductionTests.swift */; };
 		D490927A1A98F11A00275C79 /* CollectionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D49092791A98F11A00275C79 /* CollectionTests.swift */; };
 		D490927B1A98F11A00275C79 /* CollectionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D49092791A98F11A00275C79 /* CollectionTests.swift */; };
 		D4BC5E021A98C8B4008C6851 /* Madness.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = D4BC5DF71A98C8B4008C6851 /* Madness.framework */; };
@@ -73,6 +75,7 @@
 /* Begin PBXFileReference section */
 		D421A2A51A9A8DD4009AC3B1 /* Ignore.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Ignore.swift; sourceTree = "<group>"; };
 		D421A2A81A9A8E33009AC3B1 /* IgnoreTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = IgnoreTests.swift; sourceTree = "<group>"; };
+		D421A2AB1A9A9540009AC3B1 /* ReductionTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = ReductionTests.swift; path = MadnessTests/ReductionTests.swift; sourceTree = SOURCE_ROOT; };
 		D49092791A98F11A00275C79 /* CollectionTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = CollectionTests.swift; sourceTree = "<group>"; };
 		D4BC5DF71A98C8B4008C6851 /* Madness.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Madness.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		D4BC5E011A98C8B4008C6851 /* Madness-iOSTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = "Madness-iOSTests.xctest"; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -172,9 +175,9 @@
 				D4FC47CD1A37E48800D23A6F /* Parser.swift */,
 				D4C2EDAD1A98D52B00054FAA /* Alternation.swift */,
 				D4C2EDBB1A98D8F800054FAA /* FlatMap.swift */,
+				D421A2A51A9A8DD4009AC3B1 /* Ignore.swift */,
 				D4C2EDA61A98D38E00054FAA /* Concatenation.swift */,
 				D4C2EDB31A98D63600054FAA /* Repetition.swift */,
-				D421A2A51A9A8DD4009AC3B1 /* Ignore.swift */,
 				D4FC47B41A37E47C00D23A6F /* Supporting Files */,
 			);
 			path = Madness;
@@ -199,8 +202,9 @@
 				D49092791A98F11A00275C79 /* CollectionTests.swift */,
 				D4C2EDA81A98D49500054FAA /* ConcatenationTests.swift */,
 				D4C8B02D1A69B1A900943303 /* FlatMapTests.swift */,
-				D4C2EDB81A98D82200054FAA /* RepetitionTests.swift */,
 				D421A2A81A9A8E33009AC3B1 /* IgnoreTests.swift */,
+				D421A2AB1A9A9540009AC3B1 /* ReductionTests.swift */,
+				D4C2EDB81A98D82200054FAA /* RepetitionTests.swift */,
 				D4FC47C11A37E47C00D23A6F /* Supporting Files */,
 			);
 			path = MadnessTests;
@@ -408,6 +412,7 @@
 				D4BC5E121A98C97C008C6851 /* ParserTests.swift in Sources */,
 				D4C2EDB21A98D5DB00054FAA /* AlternationTests.swift in Sources */,
 				D421A2AA1A9A8E33009AC3B1 /* IgnoreTests.swift in Sources */,
+				D421A2AD1A9A9540009AC3B1 /* ReductionTests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -435,6 +440,7 @@
 				D4FC47C41A37E47C00D23A6F /* ParserTests.swift in Sources */,
 				D4C2EDB11A98D5DB00054FAA /* AlternationTests.swift in Sources */,
 				D421A2A91A9A8E33009AC3B1 /* IgnoreTests.swift in Sources */,
+				D421A2AC1A9A9540009AC3B1 /* ReductionTests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/Madness/Parser.swift
+++ b/Madness/Parser.swift
@@ -72,9 +72,9 @@ public func --> <C: CollectionType, T, U>(parser: Parser<C, T>.Function, f: T ->
 /// Returns a parser which maps parse trees into another type.
 ///
 /// This overload also receives the index that parsing ended at.
-public func --> <C: CollectionType, T, U>(parser: Parser<C, T>.Function, f: (C, C.Index, T) -> U) -> Parser<C, U>.Function {
+public func --> <C: CollectionType, T, U>(parser: Parser<C, T>.Function, f: (C, Range<C.Index>, T) -> U) -> Parser<C, U>.Function {
 	return { input, index in
-		parser(input, index).map { (f(input, $1, $0), $1) }
+		parser(input, index).map { (f(input, index..<$1, $0), $1) }
 	}
 }
 

--- a/Madness/Parser.swift
+++ b/Madness/Parser.swift
@@ -72,9 +72,9 @@ public func --> <C: CollectionType, T, U>(parser: Parser<C, T>.Function, f: T ->
 /// Returns a parser which maps parse trees into another type.
 ///
 /// This overload also receives the index that parsing ended at.
-public func --> <C: CollectionType, T, U>(parser: Parser<C, T>.Function, f: (C.Index, T) -> U) -> Parser<C, U>.Function {
-	return {
-		parser($0).map { (f($1, $0), $1) }
+public func --> <C: CollectionType, T, U>(parser: Parser<C, T>.Function, f: (C, C.Index, T) -> U) -> Parser<C, U>.Function {
+	return { input, index in
+		parser(input, index).map { (f(input, $1, $0), $1) }
 	}
 }
 

--- a/Madness/Parser.swift
+++ b/Madness/Parser.swift
@@ -58,27 +58,6 @@ public prefix func %<I: IntervalType where I.Bound == Character>(interval: I) ->
 }
 
 
-// MARK: - Nonterminals
-
-// MARK: Mapping
-
-/// Returns a parser which maps parse trees into another type.
-public func --> <C: CollectionType, T, U>(parser: Parser<C, T>.Function, f: T -> U) -> Parser<C, U>.Function {
-	return {
-		parser($0).map { (f($0), $1) }
-	}
-}
-
-/// Returns a parser which maps parse trees into another type.
-///
-/// This overload also receives the index that parsing ended at.
-public func --> <C: CollectionType, T, U>(parser: Parser<C, T>.Function, f: (C, Range<C.Index>, T) -> U) -> Parser<C, U>.Function {
-	return { input, index in
-		parser(input, index).map { (f(input, index..<$1, $0), $1) }
-	}
-}
-
-
 // MARK: - Private
 
 /// Returns `true` iff `collection` contains all of the elements in `needle` in-order and contiguously, starting from `index`.

--- a/Madness/Parser.swift
+++ b/Madness/Parser.swift
@@ -72,9 +72,9 @@ public func --> <C: CollectionType, T, U>(parser: Parser<C, T>.Function, f: T ->
 /// Returns a parser which maps parse trees into another type.
 ///
 /// This overload also receives the index that parsing ended at.
-public func --> <C: CollectionType, T, U>(parser: Parser<C, T>.Function, f: (T, C.Index) -> U) -> Parser<C, U>.Function {
+public func --> <C: CollectionType, T, U>(parser: Parser<C, T>.Function, f: (C.Index, T) -> U) -> Parser<C, U>.Function {
 	return {
-		parser($0).map { (f($0, $1), $1) }
+		parser($0).map { (f($1, $0), $1) }
 	}
 }
 

--- a/Madness/Parser.swift
+++ b/Madness/Parser.swift
@@ -69,6 +69,15 @@ public func --> <C: CollectionType, T, U>(parser: Parser<C, T>.Function, f: T ->
 	}
 }
 
+/// Returns a parser which maps parse trees into another type.
+///
+/// This overload also receives the index that parsing ended at.
+public func --> <C: CollectionType, T, U>(parser: Parser<C, T>.Function, f: (T, C.Index) -> U) -> Parser<C, U>.Function {
+	return {
+		parser($0).map { (f($0, $1), $1) }
+	}
+}
+
 
 // MARK: - Private
 

--- a/Madness/Reduction.swift
+++ b/Madness/Reduction.swift
@@ -1,0 +1,17 @@
+//  Copyright (c) 2015 Rob Rix. All rights reserved.
+
+/// Returns a parser which maps parse trees into another type.
+public func --> <C: CollectionType, T, U>(parser: Parser<C, T>.Function, f: T -> U) -> Parser<C, U>.Function {
+	return {
+		parser($0).map { (f($0), $1) }
+	}
+}
+
+/// Returns a parser which maps parse trees into another type.
+///
+/// This overload also receives the index that parsing ended at.
+public func --> <C: CollectionType, T, U>(parser: Parser<C, T>.Function, f: (C, Range<C.Index>, T) -> U) -> Parser<C, U>.Function {
+	return { input, index in
+		parser(input, index).map { (f(input, index..<$1, $0), $1) }
+	}
+}

--- a/Madness/Repetition.swift
+++ b/Madness/Repetition.swift
@@ -12,7 +12,7 @@ public postfix func * (string: String) -> Parser<String, [String]>.Function {
 
 /// Parses `parser` 0 or more times and drops its parse trees.
 public postfix func * <C: CollectionType> (parser: Parser<C, Ignore>.Function) -> Parser<C, Ignore>.Function {
-	return repeat(parser, 0..<Int.max) --> const(Ignore())
+	return ignore(repeat(parser, 0..<Int.max))
 }
 
 /// Parses `parser` 1 or more times.
@@ -27,7 +27,7 @@ public postfix func + (string: String) -> Parser<String, [String]>.Function {
 
 /// Parses `parser` 0 or more times and drops its parse trees.
 public postfix func + <C: CollectionType> (parser: Parser<C, Ignore>.Function) -> Parser<C, Ignore>.Function {
-	return repeat(parser, 1..<Int.max) --> const(Ignore())
+	return ignore(repeat(parser, 1..<Int.max))
 }
 
 /// Parses `parser` exactly `n` times.

--- a/MadnessTests/AlternationTests.swift
+++ b/MadnessTests/AlternationTests.swift
@@ -1,7 +1,7 @@
 //  Copyright (c) 2015 Rob Rix. All rights reserved.
 
 final class AlternationTests: XCTestCase {
-	let alternation = %"x" | (%"y" --> const(1))
+	let alternation = %"x" | (%"y" --> { _, _ in 1 })
 
 	func testAlternationParsesEitherAlternative() {
 		assertAdvancedBy(alternation, "xy", 1)

--- a/MadnessTests/AlternationTests.swift
+++ b/MadnessTests/AlternationTests.swift
@@ -1,7 +1,7 @@
 //  Copyright (c) 2015 Rob Rix. All rights reserved.
 
 final class AlternationTests: XCTestCase {
-	let alternation = %"x" | (%"y" --> { _, _ in 1 })
+	let alternation = %"x" | (%"y" --> { _, _, _ in 1 })
 
 	func testAlternationParsesEitherAlternative() {
 		assertAdvancedBy(alternation, "xy", 1)

--- a/MadnessTests/ReductionTests.swift
+++ b/MadnessTests/ReductionTests.swift
@@ -6,6 +6,10 @@ final class ReductionTests: XCTestCase {
 	func testMapsParseTreesWithAFunction() {
 		assertTree(reduction, "x", ==, "X")
 	}
+
+	func testRejectsInputRejectedByItsParser() {
+		assertUnmatched(reduction, "y")
+	}
 }
 
 

--- a/MadnessTests/ReductionTests.swift
+++ b/MadnessTests/ReductionTests.swift
@@ -1,0 +1,15 @@
+//  Copyright (c) 2015 Rob Rix. All rights reserved.
+
+final class ReductionTests: XCTestCase {
+	let reduction = %"x" --> { $0.uppercaseString }
+
+	func testMapsParseTreesWithAFunction() {
+		assertTree(reduction, "x", ==, "X")
+	}
+}
+
+
+// MARK: - Imports
+
+import Madness
+import XCTest

--- a/MadnessTests/ReductionTests.swift
+++ b/MadnessTests/ReductionTests.swift
@@ -10,6 +10,13 @@ final class ReductionTests: XCTestCase {
 	func testRejectsInputRejectedByItsParser() {
 		assertUnmatched(reduction, "y")
 	}
+
+
+	let reductionWithIndex = %"x" --> { $2.uppercaseString + String(distance($0.startIndex, $1)) }
+
+	func testMapsParseTreesWithAFunctionWhichTakesTheSourceIndex() {
+		assertTree(reductionWithIndex, "x", ==, "X1")
+	}
 }
 
 

--- a/MadnessTests/ReductionTests.swift
+++ b/MadnessTests/ReductionTests.swift
@@ -12,10 +12,10 @@ final class ReductionTests: XCTestCase {
 	}
 
 
-	let reductionWithIndex = %"x" --> { $2.uppercaseString + String(distance($0.startIndex, $1)) }
+	let reductionWithIndex = %"x" --> { "\($2.uppercaseString):\(distance($0.startIndex, $1.startIndex))..<\(distance($0.startIndex, $1.endIndex))" }
 
 	func testMapsParseTreesWithAFunctionWhichTakesTheSourceIndex() {
-		assertTree(reductionWithIndex, "x", ==, "X1")
+		assertTree(reductionWithIndex, "x", ==, "X:0..<1")
 	}
 }
 


### PR DESCRIPTION
`-->` can now accept a function taking the parse index.

Fixes #61.