### PR TITLE
Fix optional operator

### DIFF
--- a/Madness/Alternation.swift
+++ b/Madness/Alternation.swift
@@ -2,7 +2,12 @@
 
 /// Parses `parser` 0 or one time.
 public postfix func |? <C: CollectionType, T> (parser: Parser<C, T>.Function) -> Parser<C, T?>.Function {
-	return parser | { _ in nil }
+    return parser * (0...1) --> first
+}
+
+/// Parses `parser` 0 or one time dropping the parse tree.
+public postfix func |? <C: CollectionType, T> (parser: Parser<C, Ignore>.Function) -> Parser<C, Ignore>.Function {
+    return ignore(parser * (0...1))
 }
 
 

--- a/Madness/Repetition.swift
+++ b/Madness/Repetition.swift
@@ -39,14 +39,14 @@ public func * <C: CollectionType, T> (parser: Parser<C, T>.Function, n: Int) -> 
 
 /// Parses `parser` the number of times specified in `interval`.
 ///
-/// \param interval  An interval specifying the number of repetitions to perform. `0...n` means at most `n+1` repetitions; `m...Int.max` means at least `m` repetitions; and `m...n` means between `m` and `n` repetitions (inclusive).
+/// \param interval  An interval specifying the number of repetitions to perform. `0...n` means at most `n` repetitions; `m...Int.max` means at least `m` repetitions; and `m...n` means between `m` and `n` repetitions (inclusive).
 public func * <C: CollectionType, T> (parser: Parser<C, T>.Function, interval: ClosedInterval<Int>) -> Parser<C, [T]>.Function {
 	return repeat(parser, interval)
 }
 
 /// Parses `parser` the number of times specified in `interval`.
 ///
-/// \param interval  An interval specifying the number of repetitions to perform. `0..<n` means at most `n` repetitions; `m..<Int.max` means at least `m` repetitions; and `m..<n` means at least `m` and fewer than `n` repetitions.
+/// \param interval  An interval specifying the number of repetitions to perform. `0..<n` means at most `n-1` repetitions; `m..<Int.max` means at least `m` repetitions; and `m..<n` means at least `m` and fewer than `n` repetitions.
 public func * <C: CollectionType, T> (parser: Parser<C, T>.Function, interval: HalfOpenInterval<Int>) -> Parser<C, [T]>.Function {
 	return repeat(parser, interval)
 }

--- a/MadnessTests/AlternationTests.swift
+++ b/MadnessTests/AlternationTests.swift
@@ -1,8 +1,6 @@
 //  Copyright (c) 2015 Rob Rix. All rights reserved.
 
 final class AlternationTests: XCTestCase {
-	let alternation = %"x" | (%"y" --> { _, _, _ in 1 })
-
 	func testAlternationParsesEitherAlternative() {
 		assertAdvancedBy(alternation, "xy", 1)
 		assertAdvancedBy(alternation, "yx", 1)
@@ -15,7 +13,30 @@ final class AlternationTests: XCTestCase {
 	func testAlternationOfASingleTypeCoalescesTheParsedValue() {
 		assertTree(%"x" | %"y", "xy", ==, "x")
 	}
+
+    func testOptionalProducesWhenPresent() {
+        assertTree(optional, "y", ==, "y")
+        assertTree(prefixed, "xy", ==, "xy")
+        assertTree(suffixed, "yz", ==, "yz")
+        assertTree(sandwiched, "xyz", ==, "xyz")
+    }
+
+    func testOptionalProducesWhenAbsent() {
+        assertTree(optional, "", ==, "")
+        assertTree(prefixed, "x", ==, "x")
+        assertTree(suffixed, "z", ==, "z")
+        assertTree(sandwiched, "xz", ==, "xz")
+    }
 }
+
+// MARK: - Fixtures
+
+let alternation = %"x" | (%"y" --> { _, _, _ in 1 })
+
+let optional = (%"y")|? --> { $0 ?? "" }
+let prefixed = %"x" ++ optional --> { $0 + $1 }
+let suffixed = optional ++ %"z" --> { $0 + $1 }
+let sandwiched = prefixed ++ %"z" --> { $0 + $1 }
 
 
 // MARK: - Imports

--- a/MadnessTests/ConcatenationTests.swift
+++ b/MadnessTests/ConcatenationTests.swift
@@ -42,11 +42,6 @@ func assertTree<C: CollectionType, T>(parser: Parser<C, T>.Function, input: C, m
 	return Assertions.assert(parsed?.0, match, tree, message: "should have parsed \(input) as \(tree). " + message, file: file, line: line)
 }
 
-func assertTree<C: CollectionType, T>(parser: Parser<C, T>.Function, input: C, match: ((T, C.Index), T) -> Bool, tree: T, message: String = "", file: String = __FILE__, line: UInt = __LINE__) -> (T, C.Index)? {
-	let parsed: Parser<C, T>.Result = parser(input, input.startIndex)
-	return Assertions.assert(parsed, match, tree, message: "should have parsed \(input) as \(tree). " + message, file: file, line: line)
-}
-
 func assertAdvancedBy<C: CollectionType, T>(parser: Parser<C, T>.Function, input: C, offset: C.Index.Distance, message: String = "", file: String = __FILE__, line: UInt = __LINE__) -> C.Index? {
 	return assertEqual(assertNotNil(parser(input, input.startIndex), "should have parsed \(input) and advanced by \(offset). " + message, file: file, line: line)?.1, advance(input.startIndex, offset), "should have parsed \(input) and advanced by \(offset). " + message, file, line)
 }


### PR DESCRIPTION
Previously it didn't parse if the optional was absent.