### PR TITLE
Add some interesting combinators that build on alternation over sequences

### DIFF
--- a/Madness.xcodeproj/project.pbxproj
+++ b/Madness.xcodeproj/project.pbxproj
@@ -159,6 +159,7 @@
 				D4FC47B21A37E47C00D23A6F /* Products */,
 			);
 			sourceTree = "<group>";
+			usesTabs = 1;
 		};
 		D4FC47B21A37E47C00D23A6F /* Products */ = {
 			isa = PBXGroup;

--- a/Madness/Alternation.swift
+++ b/Madness/Alternation.swift
@@ -44,6 +44,17 @@ public func oneOf<C: CollectionType, S: SequenceType where C.Generator.Element: 
 	return reduce(input, none()) { $0 | %$1 }
 }
 
+/// Given a set of literals, parses an array of any matches in the order they were found.
+///
+/// Each literal will only match the first time.
+public func anyOf<C: CollectionType where C.Generator.Element: Equatable>(set: Set<C>) -> Parser<C, [C]>.Function {
+	return oneOf(set) >>- { match in
+		var rest = set
+		rest.remove(match)
+		return anyOf(rest) >>- { inject([match] + $0) } | inject([match])
+	}
+}
+
 
 // MARK: - Private
 

--- a/Madness/Alternation.swift
+++ b/Madness/Alternation.swift
@@ -51,7 +51,7 @@ public func anyOf<C: CollectionType where C.Generator.Element: Equatable>(set: S
 	return oneOf(set) >>- { match in
 		var rest = set
 		rest.remove(match)
-		return anyOf(rest) >>- { inject([match] + $0) } | inject([match])
+		return anyOf(rest) >>- { pure([match] + $0) } | pure([match])
 	}
 }
 
@@ -60,7 +60,7 @@ public func anyOf<C: CollectionType where C.Generator.Element: Equatable>(set: S
 /// Each literal will be matched as many times as it is found.
 public func allOf<C: CollectionType where C.Generator.Element: Equatable>(input: Set<C>) -> Parser<C, [C]>.Function {
 	return oneOf(input) >>- { match in
-		allOf(input) >>- { inject([match] + $0) } | inject([match])
+		allOf(input) >>- { pure([match] + $0) } | pure([match])
 	}
 }
 

--- a/Madness/Alternation.swift
+++ b/Madness/Alternation.swift
@@ -37,6 +37,14 @@ public func | <C: CollectionType> (left: Parser<C, Ignore>.Function, right: Pars
 }
 
 
+// MARK: - n-ary alternation
+
+/// Alternates over a sequence of literals, coalescing their parse trees.
+public func oneOf<C: CollectionType, S: SequenceType where C.Generator.Element: Equatable, S.Generator.Element == C>(input: S) -> Parser<C, C>.Function {
+	return reduce(input, none()) { $0 | %$1 }
+}
+
+
 // MARK: - Private
 
 /// Defines alternation for use in the `|` operator definitions above.

--- a/Madness/Alternation.swift
+++ b/Madness/Alternation.swift
@@ -55,6 +55,15 @@ public func anyOf<C: CollectionType where C.Generator.Element: Equatable>(set: S
 	}
 }
 
+/// Given a set of literals, parses an array of all matches in the order they were found.
+///
+/// Each literal will be matched as many times as it is found.
+public func allOf<C: CollectionType where C.Generator.Element: Equatable>(input: Set<C>) -> Parser<C, [C]>.Function {
+	return oneOf(input) >>- { match in
+		allOf(input) >>- { inject([match] + $0) } | inject([match])
+	}
+}
+
 
 // MARK: - Private
 

--- a/Madness/FlatMap.swift
+++ b/Madness/FlatMap.swift
@@ -12,7 +12,7 @@ public func >>- <C: CollectionType, T, U> (parser: Parser<C, T>.Function, f: T -
 /// Returns a parser which always ignores its input and produces a constant value.
 ///
 /// When combining parsers with `>>-`, allows constant values to be injected into the parser chain.
-public func inject<C: CollectionType, T>(value: T) -> Parser<C, T>.Function {
+public func pure<C: CollectionType, T>(value: T) -> Parser<C, T>.Function {
 	return { _, index in (value, index) }
 }
 

--- a/Madness/FlatMap.swift
+++ b/Madness/FlatMap.swift
@@ -9,6 +9,13 @@ public func >>- <C: CollectionType, T, U> (parser: Parser<C, T>.Function, f: T -
 	}
 }
 
+/// Returns a parser which always ignores its input and produces a constant value.
+///
+/// When combining parsers with `>>-`, allows constant values to be injected into the parser chain.
+public func inject<C: CollectionType, T>(value: T) -> Parser<C, T>.Function {
+	return { _, index in (value, index) }
+}
+
 
 // MARK: - Operators
 

--- a/Madness/Parser.swift
+++ b/Madness/Parser.swift
@@ -20,6 +20,11 @@ public func parse<C: CollectionType, Tree>(parser: Parser<C, Tree>.Function, inp
 
 // MARK: - Terminals
 
+/// Returns a parser which never parses its input.
+public func none<C: CollectionType, Tree>() -> Parser<C, Tree>.Function {
+	return const(nil)
+}
+
 /// Returns a parser which parses any single character.
 public func any(input: String, index: String.Index) -> Parser<String, String>.Result {
 	return index < input.endIndex ? (input[index..<advance(index, 1)], index.successor()) : nil

--- a/MadnessTests/AlternationTests.swift
+++ b/MadnessTests/AlternationTests.swift
@@ -63,6 +63,25 @@ final class AlternationTests: XCTestCase {
 		assertTree(xyz, "xyy", ==, ["x", "y"])
 	}
 
+
+	// MARK: All-of
+
+	func testAllOfParsesAnArrayOfMatchesPreservingOrder() {
+		let xyz = allOf(["x", "y", "z"])
+		assertTree(xyz, "xy", ==, ["x", "y"])
+		assertTree(xyz, "yx", ==, ["y", "x"])
+		assertTree(xyz, "zxy", ==, ["z", "x", "y"])
+	}
+
+	func testAllOfRejectsWhenNoneMatch() {
+		assertUnmatched(allOf(["x"]), "y")
+	}
+
+	func testAllOfParsesAllMatches() {
+		let xyz = allOf(["x", "y", "z"])
+		assertTree(xyz, "xyyxz", ==, ["x", "y", "y", "x", "z"])
+	}
+
 }
 
 // MARK: - Fixtures

--- a/MadnessTests/AlternationTests.swift
+++ b/MadnessTests/AlternationTests.swift
@@ -1,6 +1,9 @@
 //  Copyright (c) 2015 Rob Rix. All rights reserved.
 
 final class AlternationTests: XCTestCase {
+
+	// MARK: Alternation
+
 	func testAlternationParsesEitherAlternative() {
 		assertAdvancedBy(alternation, "xy", 1)
 		assertAdvancedBy(alternation, "yx", 1)
@@ -13,6 +16,9 @@ final class AlternationTests: XCTestCase {
 	func testAlternationOfASingleTypeCoalescesTheParsedValue() {
 		assertTree(%"x" | %"y", "xy", ==, "x")
 	}
+
+
+	// MARK: Optional
 
 	func testOptionalProducesWhenPresent() {
 		assertTree(optional, "y", ==, "y")
@@ -27,6 +33,17 @@ final class AlternationTests: XCTestCase {
 		assertTree(suffixed, "z", ==, "z")
 		assertTree(sandwiched, "xz", ==, "xz")
 	}
+
+
+	// MARK: One-of
+
+	func testOneOfParsesFirstMatch() {
+		let xyz = oneOf(["x", "y", "z"])
+		assertTree(xyz, "xyz", ==, "x")
+		assertTree(xyz, "yzx", ==, "y")
+		assertTree(xyz, "zxy", ==, "z")
+	}
+
 }
 
 // MARK: - Fixtures

--- a/MadnessTests/AlternationTests.swift
+++ b/MadnessTests/AlternationTests.swift
@@ -44,6 +44,25 @@ final class AlternationTests: XCTestCase {
 		assertTree(xyz, "zxy", ==, "z")
 	}
 
+
+	// MARK: Any-of
+
+	func testAnyOfParsesAnArrayOfMatchesPreservingOrder() {
+		let xyz = anyOf(["x", "y", "z"])
+		assertTree(xyz, "xy", ==, ["x", "y"])
+		assertTree(xyz, "yx", ==, ["y", "x"])
+		assertTree(xyz, "zxy", ==, ["z", "x", "y"])
+	}
+
+	func testAnyOfRejectsWhenNoneMatch() {
+		assertUnmatched(anyOf(["x"]), "y")
+	}
+
+	func testAnyOfOnlyParsesFirstMatch() {
+		let xyz = anyOf(["x", "y", "z"])
+		assertTree(xyz, "xyy", ==, ["x", "y"])
+	}
+
 }
 
 // MARK: - Fixtures

--- a/MadnessTests/AlternationTests.swift
+++ b/MadnessTests/AlternationTests.swift
@@ -38,20 +38,18 @@ final class AlternationTests: XCTestCase {
 	// MARK: One-of
 
 	func testOneOfParsesFirstMatch() {
-		let xyz = oneOf(["x", "y", "z"])
-		assertTree(xyz, "xyz", ==, "x")
-		assertTree(xyz, "yzx", ==, "y")
-		assertTree(xyz, "zxy", ==, "z")
+		assertTree(one, "xyz", ==, "x")
+		assertTree(one, "yzx", ==, "y")
+		assertTree(one, "zxy", ==, "z")
 	}
 
 
 	// MARK: Any-of
 
 	func testAnyOfParsesAnArrayOfMatchesPreservingOrder() {
-		let xyz = anyOf(["x", "y", "z"])
-		assertTree(xyz, "xy", ==, ["x", "y"])
-		assertTree(xyz, "yx", ==, ["y", "x"])
-		assertTree(xyz, "zxy", ==, ["z", "x", "y"])
+		assertTree(any, "xy", ==, ["x", "y"])
+		assertTree(any, "yx", ==, ["y", "x"])
+		assertTree(any, "zxy", ==, ["z", "x", "y"])
 	}
 
 	func testAnyOfRejectsWhenNoneMatch() {
@@ -59,18 +57,16 @@ final class AlternationTests: XCTestCase {
 	}
 
 	func testAnyOfOnlyParsesFirstMatch() {
-		let xyz = anyOf(["x", "y", "z"])
-		assertTree(xyz, "xyy", ==, ["x", "y"])
+		assertTree(any, "xyy", ==, ["x", "y"])
 	}
 
 
 	// MARK: All-of
 
 	func testAllOfParsesAnArrayOfMatchesPreservingOrder() {
-		let xyz = allOf(["x", "y", "z"])
-		assertTree(xyz, "xy", ==, ["x", "y"])
-		assertTree(xyz, "yx", ==, ["y", "x"])
-		assertTree(xyz, "zxy", ==, ["z", "x", "y"])
+		assertTree(all, "xy", ==, ["x", "y"])
+		assertTree(all, "yx", ==, ["y", "x"])
+		assertTree(all, "zxy", ==, ["z", "x", "y"])
 	}
 
 	func testAllOfRejectsWhenNoneMatch() {
@@ -78,8 +74,7 @@ final class AlternationTests: XCTestCase {
 	}
 
 	func testAllOfParsesAllMatches() {
-		let xyz = allOf(["x", "y", "z"])
-		assertTree(xyz, "xyyxz", ==, ["x", "y", "y", "x", "z"])
+		assertTree(all, "xyyxz", ==, ["x", "y", "y", "x", "z"])
 	}
 
 }
@@ -92,6 +87,10 @@ let optional = (%"y")|? --> { $0 ?? "" }
 let prefixed = %"x" ++ optional --> { $0 + $1 }
 let suffixed = optional ++ %"z" --> { $0 + $1 }
 let sandwiched = prefixed ++ %"z" --> { $0 + $1 }
+
+private let one = oneOf(["x", "y", "z"])
+private let any = anyOf(["x", "y", "z"])
+private let all = allOf(["x", "y", "z"])
 
 
 // MARK: - Imports

--- a/MadnessTests/AlternationTests.swift
+++ b/MadnessTests/AlternationTests.swift
@@ -81,12 +81,12 @@ final class AlternationTests: XCTestCase {
 
 // MARK: - Fixtures
 
-let alternation = %"x" | (%"y" --> { _, _, _ in 1 })
+private let alternation = %"x" | (%"y" --> { _, _, _ in 1 })
 
-let optional = (%"y")|? --> { $0 ?? "" }
-let prefixed = %"x" ++ optional --> { $0 + $1 }
-let suffixed = optional ++ %"z" --> { $0 + $1 }
-let sandwiched = prefixed ++ %"z" --> { $0 + $1 }
+private let optional = (%"y")|? --> { $0 ?? "" }
+private let prefixed = %"x" ++ optional --> { $0 + $1 }
+private let suffixed = optional ++ %"z" --> { $0 + $1 }
+private let sandwiched = prefixed ++ %"z" --> { $0 + $1 }
 
 private let one = oneOf(["x", "y", "z"])
 private let any = anyOf(["x", "y", "z"])

--- a/MadnessTests/AlternationTests.swift
+++ b/MadnessTests/AlternationTests.swift
@@ -14,19 +14,19 @@ final class AlternationTests: XCTestCase {
 		assertTree(%"x" | %"y", "xy", ==, "x")
 	}
 
-    func testOptionalProducesWhenPresent() {
-        assertTree(optional, "y", ==, "y")
-        assertTree(prefixed, "xy", ==, "xy")
-        assertTree(suffixed, "yz", ==, "yz")
-        assertTree(sandwiched, "xyz", ==, "xyz")
-    }
+	func testOptionalProducesWhenPresent() {
+		assertTree(optional, "y", ==, "y")
+		assertTree(prefixed, "xy", ==, "xy")
+		assertTree(suffixed, "yz", ==, "yz")
+		assertTree(sandwiched, "xyz", ==, "xyz")
+	}
 
-    func testOptionalProducesWhenAbsent() {
-        assertTree(optional, "", ==, "")
-        assertTree(prefixed, "x", ==, "x")
-        assertTree(suffixed, "z", ==, "z")
-        assertTree(sandwiched, "xz", ==, "xz")
-    }
+	func testOptionalProducesWhenAbsent() {
+		assertTree(optional, "", ==, "")
+		assertTree(prefixed, "x", ==, "x")
+		assertTree(suffixed, "z", ==, "z")
+		assertTree(sandwiched, "xz", ==, "xz")
+	}
 }
 
 // MARK: - Fixtures

--- a/MadnessTests/FlatMapTests.swift
+++ b/MadnessTests/FlatMapTests.swift
@@ -63,8 +63,8 @@ final class FlatMapTests: XCTestCase {
 		}
 	}
 
-	func testInjectIgnoresItsInput() {
-		assertTree(inject("a"), "b", ==, "a")
+	func testPureIgnoresItsInput() {
+		assertTree(pure("a"), "b", ==, "a")
 	}
 }
 

--- a/MadnessTests/FlatMapTests.swift
+++ b/MadnessTests/FlatMapTests.swift
@@ -62,6 +62,10 @@ final class FlatMapTests: XCTestCase {
 			XCTAssert(parse(tree(0), input) == nil)
 		}
 	}
+
+	func testInjectIgnoresItsInput() {
+		assertTree(inject("a"), "b", ==, "a")
+	}
 }
 
 

--- a/MadnessTests/ParserTests.swift
+++ b/MadnessTests/ParserTests.swift
@@ -48,6 +48,22 @@ final class ParserTests: XCTestCase {
 	}
 
 
+	// MARK: None
+
+	func testNoneDoesNotConsumeItsInput() {
+		assertTree(none() | %"a", "a", ==, "a")
+	}
+
+	func testNoneIsIdentityForAlternation() {
+		typealias Parser = Madness.Parser<String, String>.Function
+		let alternate: (Parser, Parser) -> Parser = { $0 | $1 }
+		let parser = reduce([%"a", %"b", %"c"], none(), alternate)
+		assertTree(parser, "a", ==, "a")
+		assertTree(parser, "b", ==, "b")
+		assertTree(parser, "c", ==, "c")
+	}
+
+
 	// MARK: Any
 
 	func testAnyRejectsTheEmptyString() {


### PR DESCRIPTION
Let me preface this by saying that may agenda here was ultimately to build the
`anyOf()` combinator for my own purposes — I don't know if this is the kind of
thing you want to be included in Madness core! But along the way I discovered
some interesting and fun things, and if any of them fit then feel free to
cherry-pick just those. I've got what I was looking for. :innocent:

A brief summary:

- `inject()`: A name that I came up with for monadic `return` over parsers.
  (I'm not super attached to the name.)

- `oneOf()`: Kinda looks like `mconcat` over parsers (!), but limited to literals.
  (I'm guessing that `mconcat` wouldn't really be possible because of the
  trouble with function types in generic constraints, and the general lack of
  higher-kinded types.)

- `anyOf()`: That's what I came here for. I'm planning to use this one to parse
  abbreviated short option strings, e.g., `-la => [-l, -a] // "any of" l or a`.
  It's interesting, but up to you whether it's suitable for inclusion in Madness.

- `allOf()`: Logical addition to go alongside `anyOf()`. Basically a greedier
  version that pulls out all the matches from the set of literals.

Thanks for the great library, this was a lot of fun! Looking forward to your
feedback. :blush: