### PR TITLE
Add <^> and curried map()

### DIFF
--- a/Cartfile
+++ b/Cartfile
@@ -1,1 +1,1 @@
-github "robrix/Either" ~> 1.2
+github "robrix/Either" "b31d1ee"

--- a/Cartfile.resolved
+++ b/Cartfile.resolved
@@ -1,4 +1,4 @@
 github "antitypical/Assertions" "v1.1-beta.1"
 github "robrix/Box" "18d05a56845837eea90a36854c67de2520983bf8"
 github "robrix/Prelude" "180e9ae5e60ec47abd8f3e0fa68cafbbbd160abe"
-github "robrix/Either" "1.2"
+github "robrix/Either" "b31d1eec2bccf0688ecba8ab3140358293cc16c1"

--- a/Documentation/Collections.playground/section-2.swift
+++ b/Documentation/Collections.playground/section-2.swift
@@ -4,9 +4,9 @@ typealias Fibonacci = Parser<[Int], [Int]>.Function
 
 let fibonacci: (Int, Int) -> Fibonacci = fix { fibonacci in
 	{ (x: Int, y: Int) -> Fibonacci in
-		%(x + y) >>- { (xy: Int) -> Fibonacci in
+		(%(x + y) >>- { (xy: Int) -> Fibonacci in
 			fibonacci(y, xy) |> map { [ xy ] + $0 }
-		} | { ([], $1) }
+		}) | { ([], $1) }
 	}
 }
 

--- a/Documentation/Collections.playground/section-2.swift
+++ b/Documentation/Collections.playground/section-2.swift
@@ -5,7 +5,7 @@ typealias Fibonacci = Parser<[Int], [Int]>.Function
 let fibonacci: (Int, Int) -> Fibonacci = fix { fibonacci in
 	{ (x: Int, y: Int) -> Fibonacci in
 		%(x + y) >>- { (xy: Int) -> Fibonacci in
-			fibonacci(y, xy) --> { [ xy ] + $0 }
+			fibonacci(y, xy) |> map { [ xy ] + $0 }
 		} | { ([], $1) }
 	}
 }

--- a/Documentation/Colours.playground/section-2.swift
+++ b/Documentation/Colours.playground/section-2.swift
@@ -1,16 +1,18 @@
-let toComponent: String -> CGFloat = { CGFloat(strtol($0, nil, 16)) / 255 }
+func toComponent(string: String) -> CGFloat {
+  return CGFloat(strtol(string, nil, 16)) / 255
+}
 
 let digit = %("0"..."9")
 let lower = %("a"..."f")
 let upper = %("A"..."F")
 let hex = digit | lower | upper
-let hex2 = (hex ++ hex --> { $0 + $1 })
-let component1: Parser<String, CGFloat>.Function = hex --> { toComponent($0 + $0) }
-let component2: Parser<String, CGFloat>.Function = hex2 --> toComponent
+let hex2 = (hex ++ hex |> map { $0 + $1 })
+let component1: Parser<String, CGFloat>.Function = hex |> map { toComponent($0 + $0) }
+let component2: Parser<String, CGFloat>.Function = toComponent <^> hex2
 let three: Parser<String, [CGFloat]>.Function = component1 * 3
 let six: Parser<String, [CGFloat]>.Function = component2 * 3
 
-let colour: Parser<String, NSColor>.Function = ignore("#") ++ (six | three) --> {
+let colour: Parser<String, NSColor>.Function = ignore("#") ++ (six | three) |> map {
 	NSColor(calibratedRed: $0[0], green: $0[1], blue: $0[2], alpha: 1)
 }
 

--- a/Documentation/Lambda Calculus.playground/section-2.swift
+++ b/Documentation/Lambda Calculus.playground/section-2.swift
@@ -19,10 +19,10 @@ enum Term: Printable {
 let symbol = %("a"..."z")
 
 let term: Parser<String, Term>.Function = fix { (term: Parser<String, Term>.Function) -> Parser<String, Term>.Function in
-	let variable: Parser<String, Term>.Function = symbol --> { Term.Variable($0) }
-	let abstraction: Parser<String, Term>.Function = ignore("λ") ++ symbol ++ ignore(".") ++ term --> { Term.Abstraction($0, Box($1)) }
+	let variable: Parser<String, Term>.Function = symbol |> map { Term.Variable($0) }
+	let abstraction: Parser<String, Term>.Function = ignore("λ") ++ symbol ++ ignore(".") ++ term |> map { Term.Abstraction($0, Box($1)) }
 	let parenthesized: Parser<String, (Term, Term)>.Function = ignore("(") ++ term ++ ignore(" ") ++ term ++ ignore(")")
-	let application: Parser<String, Term>.Function = parenthesized --> { (function: Term, argument: Term) -> Term in
+	let application: Parser<String, Term>.Function = parenthesized |> map { (function: Term, argument: Term) -> Term in
 		Term.Application(Box(function), Box(argument))
 	}
 	return variable | abstraction | application

--- a/Documentation/Subset of Common Markdown.playground/section-2.swift
+++ b/Documentation/Subset of Common Markdown.playground/section-2.swift
@@ -42,7 +42,7 @@ enum Node: Printable {
 
 // MARK: - Parsing rules
 
-typealias NodeParser = Parser<String, ()>.Function -> Parser<String, Node>.Function
+typealias NodeParser = Parser<String, Ignore>.Function -> Parser<String, Node>.Function
 
 let element: NodeParser = fix { element in
 	{ prefix in
@@ -60,7 +60,7 @@ let element: NodeParser = fix { element in
 	}
 }
 
-let ok: Parser<String, ()>.Function = { ((), $1) }
+let ok: Parser<String, Ignore>.Function = { (Ignore(), $1) }
 let parsed = parse(element(ok), "> # hello\n> \n> hello\n> there\n> \n> \n")
 if let translated = parsed.0 {
 	translated.description

--- a/Documentation/Subset of Common Markdown.playground/section-2.swift
+++ b/Documentation/Subset of Common Markdown.playground/section-2.swift
@@ -6,7 +6,7 @@ let lower = %("a"..."z")
 let upper = %("A"..."Z")
 let digit = %("0"..."9")
 let text = lower | upper | digit | ws
-let restOfLine: Parser<String, String>.Function = (text+ --> { "".join($0) }) ++ newline
+let restOfLine: Parser<String, String>.Function = (text+ |> map { "".join($0) }) ++ newline
 
 
 // MARK: - AST
@@ -47,13 +47,13 @@ typealias NodeParser = Parser<String, Ignore>.Function -> Parser<String, Node>.F
 let element: NodeParser = fix { element in
 	{ prefix in
 		let prefixedElements: NodeParser = {
-			let each = (element(prefix ++ $0) | (prefix ++ $0 ++ newline)) --> { $0.map { [ $0 ] } ?? [] }
-			return (each)+ --> { Node.Blockquote(join([], $0)) }
+			let each = (element(prefix ++ $0) | (prefix ++ $0 ++ newline)) |> map { $0.map { [ $0 ] } ?? [] }
+      return (each)+ |> map { Node.Blockquote(join([], $0)) }
 		}
 
-		let octothorpes: Parser<String, Int>.Function = (%"#" * (1..<7)) --> { $0.count }
-		let header: Parser<String, Node>.Function = prefix ++ octothorpes ++ ignore(" ") ++ restOfLine --> { (level: Int, title: String) in Node.Header(level, title) }
-		let paragraph: Parser<String, Node>.Function = (prefix ++ restOfLine)+ --> { Node.Paragraph("\n".join($0)) }
+		let octothorpes: Parser<String, Int>.Function = (%"#" * (1..<7)) |> map { $0.count }
+		let header: Parser<String, Node>.Function = prefix ++ octothorpes ++ ignore(" ") ++ restOfLine |> map { (level: Int, title: String) in Node.Header(level, title) }
+		let paragraph: Parser<String, Node>.Function = (prefix ++ restOfLine)+ |> map { Node.Paragraph("\n".join($0)) }
 		let blockquote: Parser<String, Node>.Function = prefix ++ { prefixedElements(ignore("> "))($0, $1) }
 
 		return header | paragraph | blockquote

--- a/Documentation/Subset of Common Markdown.playground/timeline.xctimeline
+++ b/Documentation/Subset of Common Markdown.playground/timeline.xctimeline
@@ -3,7 +3,9 @@
    version = "3.0">
    <TimelineItems>
       <LoggerValueHistoryTimelineItem
-         documentLocation = "#CharacterRangeLen=22&amp;CharacterRangeLoc=1729&amp;EndingColumnNumber=24&amp;EndingLineNumber=63&amp;StartingColumnNumber=2&amp;StartingLineNumber=63&amp;Timestamp=445797849.226526">
+         documentLocation = "#CharacterRangeLen=22&amp;CharacterRangeLoc=1754&amp;EndingColumnNumber=24&amp;EndingLineNumber=63&amp;StartingColumnNumber=2&amp;StartingLineNumber=63&amp;Timestamp=452401617.789269"
+         selectedRepresentationIndex = "0"
+         shouldTrackSuperviewWidth = "NO">
       </LoggerValueHistoryTimelineItem>
    </TimelineItems>
 </Timeline>

--- a/Madness.xcodeproj/project.pbxproj
+++ b/Madness.xcodeproj/project.pbxproj
@@ -20,7 +20,7 @@
 		D4BC5E021A98C8B4008C6851 /* Madness.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = D4BC5DF71A98C8B4008C6851 /* Madness.framework */; };
 		D4BC5E101A98C978008C6851 /* Parser.swift in Sources */ = {isa = PBXBuildFile; fileRef = D4FC47CD1A37E48800D23A6F /* Parser.swift */; };
 		D4BC5E121A98C97C008C6851 /* ParserTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D4FC47C31A37E47C00D23A6F /* ParserTests.swift */; };
-		D4BC5E131A98C97C008C6851 /* FlatMapTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D4C8B02D1A69B1A900943303 /* FlatMapTests.swift */; };
+		D4BC5E131A98C97C008C6851 /* MapTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D4C8B02D1A69B1A900943303 /* MapTests.swift */; };
 		D4BC5E151A98C9A6008C6851 /* Box.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = D4FC47D31A37EFCC00D23A6F /* Box.framework */; };
 		D4BC5E161A98C9A6008C6851 /* Either.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = D4FC47D11A37EF9800D23A6F /* Either.framework */; };
 		D4BC5E171A98C9A6008C6851 /* Prelude.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = D4FC47D41A37EFCC00D23A6F /* Prelude.framework */; };
@@ -39,10 +39,10 @@
 		D4C2EDB71A98D65400054FAA /* Repetition.swift in Sources */ = {isa = PBXBuildFile; fileRef = D4C2EDB31A98D63600054FAA /* Repetition.swift */; };
 		D4C2EDB91A98D82200054FAA /* RepetitionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D4C2EDB81A98D82200054FAA /* RepetitionTests.swift */; };
 		D4C2EDBA1A98D82200054FAA /* RepetitionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D4C2EDB81A98D82200054FAA /* RepetitionTests.swift */; };
-		D4C2EDBC1A98D8F800054FAA /* FlatMap.swift in Sources */ = {isa = PBXBuildFile; fileRef = D4C2EDBB1A98D8F800054FAA /* FlatMap.swift */; };
-		D4C2EDBD1A98D8F800054FAA /* FlatMap.swift in Sources */ = {isa = PBXBuildFile; fileRef = D4C2EDBB1A98D8F800054FAA /* FlatMap.swift */; };
+		D4C2EDBC1A98D8F800054FAA /* Map.swift in Sources */ = {isa = PBXBuildFile; fileRef = D4C2EDBB1A98D8F800054FAA /* Map.swift */; };
+		D4C2EDBD1A98D8F800054FAA /* Map.swift in Sources */ = {isa = PBXBuildFile; fileRef = D4C2EDBB1A98D8F800054FAA /* Map.swift */; };
 		D4C2EDFC1A98DEE800054FAA /* Madness.h in Headers */ = {isa = PBXBuildFile; fileRef = D4FC47B61A37E47C00D23A6F /* Madness.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		D4C8B02E1A69B1A900943303 /* FlatMapTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D4C8B02D1A69B1A900943303 /* FlatMapTests.swift */; };
+		D4C8B02E1A69B1A900943303 /* MapTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D4C8B02D1A69B1A900943303 /* MapTests.swift */; };
 		D4D5B0ED1A98E03400BE42A2 /* Assertions.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = D4D5B0EC1A98E03400BE42A2 /* Assertions.framework */; };
 		D4D5B0EE1A98E2B600BE42A2 /* Assertions.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = D4D5B0EC1A98E03400BE42A2 /* Assertions.framework */; };
 		D4FC47B71A37E47C00D23A6F /* Madness.h in Headers */ = {isa = PBXBuildFile; fileRef = D4FC47B61A37E47C00D23A6F /* Madness.h */; settings = {ATTRIBUTES = (Public, ); }; };
@@ -88,8 +88,8 @@
 		D4C2EDB01A98D5DB00054FAA /* AlternationTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AlternationTests.swift; sourceTree = "<group>"; };
 		D4C2EDB31A98D63600054FAA /* Repetition.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Repetition.swift; sourceTree = "<group>"; };
 		D4C2EDB81A98D82200054FAA /* RepetitionTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = RepetitionTests.swift; sourceTree = "<group>"; };
-		D4C2EDBB1A98D8F800054FAA /* FlatMap.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = FlatMap.swift; sourceTree = "<group>"; };
-		D4C8B02D1A69B1A900943303 /* FlatMapTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = FlatMapTests.swift; sourceTree = "<group>"; };
+		D4C2EDBB1A98D8F800054FAA /* Map.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Map.swift; sourceTree = "<group>"; };
+		D4C8B02D1A69B1A900943303 /* MapTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MapTests.swift; sourceTree = "<group>"; };
 		D4D5B0EC1A98E03400BE42A2 /* Assertions.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; path = Assertions.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		D4FC47B11A37E47C00D23A6F /* Madness.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Madness.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		D4FC47B51A37E47C00D23A6F /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
@@ -179,7 +179,7 @@
 				D4FC47CD1A37E48800D23A6F /* Parser.swift */,
 				D4C2EDAD1A98D52B00054FAA /* Alternation.swift */,
 				D4C2EDA61A98D38E00054FAA /* Concatenation.swift */,
-				D4C2EDBB1A98D8F800054FAA /* FlatMap.swift */,
+				D4C2EDBB1A98D8F800054FAA /* Map.swift */,
 				D421A2A51A9A8DD4009AC3B1 /* Ignore.swift */,
 				D47B10751A9A9A1C006701A8 /* Reduction.swift */,
 				D4C2EDB31A98D63600054FAA /* Repetition.swift */,
@@ -206,7 +206,7 @@
 				D4C2EDB01A98D5DB00054FAA /* AlternationTests.swift */,
 				D49092791A98F11A00275C79 /* CollectionTests.swift */,
 				D4C2EDA81A98D49500054FAA /* ConcatenationTests.swift */,
-				D4C8B02D1A69B1A900943303 /* FlatMapTests.swift */,
+				D4C8B02D1A69B1A900943303 /* MapTests.swift */,
 				D421A2A81A9A8E33009AC3B1 /* IgnoreTests.swift */,
 				D421A2AB1A9A9540009AC3B1 /* ReductionTests.swift */,
 				D4C2EDB81A98D82200054FAA /* RepetitionTests.swift */,
@@ -399,7 +399,7 @@
 			files = (
 				D4C2EDAF1A98D53400054FAA /* Alternation.swift in Sources */,
 				D4BC5E101A98C978008C6851 /* Parser.swift in Sources */,
-				D4C2EDBD1A98D8F800054FAA /* FlatMap.swift in Sources */,
+				D4C2EDBD1A98D8F800054FAA /* Map.swift in Sources */,
 				D4C2EDAC1A98D4DE00054FAA /* Concatenation.swift in Sources */,
 				D47B10771A9A9A1C006701A8 /* Reduction.swift in Sources */,
 				D421A2A71A9A8DD4009AC3B1 /* Ignore.swift in Sources */,
@@ -414,7 +414,7 @@
 				D4C2EDAB1A98D4D600054FAA /* ConcatenationTests.swift in Sources */,
 				D4C2EDBA1A98D82200054FAA /* RepetitionTests.swift in Sources */,
 				D490927B1A98F11A00275C79 /* CollectionTests.swift in Sources */,
-				D4BC5E131A98C97C008C6851 /* FlatMapTests.swift in Sources */,
+				D4BC5E131A98C97C008C6851 /* MapTests.swift in Sources */,
 				D4BC5E121A98C97C008C6851 /* ParserTests.swift in Sources */,
 				D4C2EDB21A98D5DB00054FAA /* AlternationTests.swift in Sources */,
 				D421A2AA1A9A8E33009AC3B1 /* IgnoreTests.swift in Sources */,
@@ -428,7 +428,7 @@
 			files = (
 				D4C2EDAE1A98D52B00054FAA /* Alternation.swift in Sources */,
 				D4FC47CE1A37E48800D23A6F /* Parser.swift in Sources */,
-				D4C2EDBC1A98D8F800054FAA /* FlatMap.swift in Sources */,
+				D4C2EDBC1A98D8F800054FAA /* Map.swift in Sources */,
 				D4C2EDA71A98D38E00054FAA /* Concatenation.swift in Sources */,
 				D47B10761A9A9A1C006701A8 /* Reduction.swift in Sources */,
 				D421A2A61A9A8DD4009AC3B1 /* Ignore.swift in Sources */,
@@ -441,7 +441,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				D4C2EDAA1A98D4D400054FAA /* ConcatenationTests.swift in Sources */,
-				D4C8B02E1A69B1A900943303 /* FlatMapTests.swift in Sources */,
+				D4C8B02E1A69B1A900943303 /* MapTests.swift in Sources */,
 				D490927A1A98F11A00275C79 /* CollectionTests.swift in Sources */,
 				D4C2EDB91A98D82200054FAA /* RepetitionTests.swift in Sources */,
 				D4FC47C41A37E47C00D23A6F /* ParserTests.swift in Sources */,

--- a/Madness/Alternation.swift
+++ b/Madness/Alternation.swift
@@ -2,7 +2,7 @@
 
 /// Parses `parser` 0 or one time.
 public postfix func |? <C: CollectionType, T> (parser: Parser<C, T>.Function) -> Parser<C, T?>.Function {
-    return first <^> (parser * (0...1))
+    return first <^> parser * (0...1)
 }
 
 /// Parses `parser` 0 or one time dropping the parse tree.
@@ -51,7 +51,7 @@ public func anyOf<C: CollectionType where C.Generator.Element: Equatable>(set: S
 	return oneOf(set) >>- { match in
 		var rest = set
 		rest.remove(match)
-		return prepend(match) <^> anyOf(rest) | pure([match])
+		return (prepend(match) <^> anyOf(rest)) | pure([match])
 	}
 }
 
@@ -60,7 +60,7 @@ public func anyOf<C: CollectionType where C.Generator.Element: Equatable>(set: S
 /// Each literal will be matched as many times as it is found.
 public func allOf<C: CollectionType where C.Generator.Element: Equatable>(input: Set<C>) -> Parser<C, [C]>.Function {
 	return oneOf(input) >>- { match in
-		prepend(match) <^> allOf(input) | pure([match])
+		(prepend(match) <^> allOf(input)) | pure([match])
 	}
 }
 

--- a/Madness/Alternation.swift
+++ b/Madness/Alternation.swift
@@ -2,7 +2,7 @@
 
 /// Parses `parser` 0 or one time.
 public postfix func |? <C: CollectionType, T> (parser: Parser<C, T>.Function) -> Parser<C, T?>.Function {
-    return parser * (0...1) --> first
+    return first <^> (parser * (0...1))
 }
 
 /// Parses `parser` 0 or one time dropping the parse tree.
@@ -18,22 +18,22 @@ public func | <C: CollectionType, T, U> (left: Parser<C, T>.Function, right: Par
 
 /// Parses either `left` or `right` and coalesces their trees.
 public func | <C: CollectionType, T> (left: Parser<C, T>.Function, right: Parser<C, T>.Function) -> Parser<C, T>.Function {
-	return alternate(left, right) --> { $0.either(ifLeft: id, ifRight: id) }
+	return alternate(left, right) |> map { $0.either(ifLeft: id, ifRight: id) }
 }
 
 /// Parses either `left` or `right`, dropping `right`’s parse tree.
 public func | <C: CollectionType, T> (left: Parser<C, T>.Function, right: Parser<C, Ignore>.Function) -> Parser<C, T?>.Function {
-	return alternate(left, right) --> { $0.either(ifLeft: unit, ifRight: const(nil)) }
+	return alternate(left, right) |> map { $0.either(ifLeft: unit, ifRight: const(nil)) }
 }
 
 /// Parses either `left` or `right`, dropping `left`’s parse tree.
 public func | <C: CollectionType, T> (left: Parser<C, Ignore>.Function, right: Parser<C, T>.Function) -> Parser<C, T?>.Function {
-	return alternate(left, right) --> { $0.either(ifLeft: const(nil), ifRight: unit) }
+	return alternate(left, right) |> map { $0.either(ifLeft: const(nil), ifRight: unit) }
 }
 
 /// Parses either `left` or `right`, dropping both parse trees.
 public func | <C: CollectionType> (left: Parser<C, Ignore>.Function, right: Parser<C, Ignore>.Function) -> Parser<C, Ignore>.Function {
-	return alternate(left, right) --> { $0.either(ifLeft: id, ifRight: id) }
+	return alternate(left, right) |> map { $0.either(ifLeft: id, ifRight: id) }
 }
 
 

--- a/Madness/Alternation.swift
+++ b/Madness/Alternation.swift
@@ -51,7 +51,7 @@ public func anyOf<C: CollectionType where C.Generator.Element: Equatable>(set: S
 	return oneOf(set) >>- { match in
 		var rest = set
 		rest.remove(match)
-		return anyOf(rest) >>- { pure([match] + $0) } | pure([match])
+		return prepend(match) <^> anyOf(rest) | pure([match])
 	}
 }
 
@@ -60,7 +60,7 @@ public func anyOf<C: CollectionType where C.Generator.Element: Equatable>(set: S
 /// Each literal will be matched as many times as it is found.
 public func allOf<C: CollectionType where C.Generator.Element: Equatable>(input: Set<C>) -> Parser<C, [C]>.Function {
 	return oneOf(input) >>- { match in
-		allOf(input) >>- { pure([match] + $0) } | pure([match])
+		prepend(match) <^> allOf(input) | pure([match])
 	}
 }
 
@@ -70,6 +70,11 @@ public func allOf<C: CollectionType where C.Generator.Element: Equatable>(input:
 /// Defines alternation for use in the `|` operator definitions above.
 private func alternate<C: CollectionType, T, U>(left: Parser<C, T>.Function, right: Parser<C, U>.Function)(input: C, index: C.Index) -> Parser<C, Either<T, U>>.Result {
 	return left(input, index).map { (.left($0), $1) } ?? right(input, index).map { (.right($0), $1) }
+}
+
+/// Curried function that prepends a value to an array.
+private func prepend<T>(value: T) -> [T] -> [T] {
+	return { [value] + $0 }
 }
 
 

--- a/Madness/Concatenation.swift
+++ b/Madness/Concatenation.swift
@@ -7,12 +7,12 @@ public func ++ <C: CollectionType, T, U> (left: Parser<C, T>.Function, right: Pa
 
 /// Parses the concatenation of `left` and `right`, dropping `right`’s parse tree.
 public func ++ <C: CollectionType, T> (left: Parser<C, T>.Function, right: Parser<C, Ignore>.Function) -> Parser<C, T>.Function {
-	return concatenate(left, right) --> { x, _ in x }
+	return concatenate(left, right) |> map { x, _ in x }
 }
 
 /// Parses the concatenation of `left` and `right`, dropping `left`’s parse tree.
 public func ++ <C: CollectionType, T> (left: Parser<C, Ignore>.Function, right: Parser<C, T>.Function) -> Parser<C, T>.Function {
-	return concatenate(left, right) --> { $1 }
+	return concatenate(left, right) |> map { _, y in y }
 }
 
 /// Parses the concatenation of `left` and `right, dropping both parse trees.
@@ -43,3 +43,8 @@ private func concatenate<C: CollectionType, T, U>(left: Parser<C, T>.Function, r
 		}
 	} ?? nil
 }
+
+
+// MARK: Imports
+
+import Prelude

--- a/Madness/Map.swift
+++ b/Madness/Map.swift
@@ -19,6 +19,11 @@ public func <^> <C: CollectionType, T, U> (f: T -> U, parser: Parser<C, T>.Funct
 	return parser >>- { pure(f($0)) }
 }
 
+/// Curried `<^>`. Returns a parser which applies `f` to transform the output of `parser`.
+public func map<C: CollectionType, T, U>(f: T -> U)(_ parser: Parser<C, T>.Function) -> Parser<C, U>.Function {
+	return f <^> parser
+}
+
 
 // MARK: - pure
 

--- a/Madness/Map.swift
+++ b/Madness/Map.swift
@@ -12,6 +12,14 @@ public func >>- <C: CollectionType, T, U> (parser: Parser<C, T>.Function, f: T -
 }
 
 
+// MARK: - map
+
+/// Returns a parser which applies `f` to transform the output of `parser`.
+public func <^> <C: CollectionType, T, U> (f: T -> U, parser: Parser<C, T>.Function) -> Parser<C, U>.Function {
+	return parser >>- { pure(f($0)) }
+}
+
+
 // MARK: - pure
 
 /// Returns a parser which always ignores its input and produces a constant value.
@@ -28,4 +36,12 @@ public func pure<C: CollectionType, T>(value: T) -> Parser<C, T>.Function {
 infix operator >>- {
 	associativity left
 	precedence 150
+}
+
+/// Map operator.
+infix operator <^> {
+	associativity left
+
+	// Higher precedence than `>>-`.
+	precedence 155
 }

--- a/Madness/Map.swift
+++ b/Madness/Map.swift
@@ -1,5 +1,7 @@
 //  Copyright (c) 2015 Rob Rix. All rights reserved.
 
+// MARK: - flatMap
+
 /// Returns a parser which requires `parser` to parse, passes its parsed trees to a function `f`, and then requires the result of `f` to parse.
 ///
 /// This can be used to conveniently make a parser which depends on earlier parsed input, for example to parse exactly the same number of characters, or to parse structurally significant indentation.
@@ -8,6 +10,9 @@ public func >>- <C: CollectionType, T, U> (parser: Parser<C, T>.Function, f: T -
 		parser(input, index).map { f($0)(input, $1) } ?? nil
 	}
 }
+
+
+// MARK: - pure
 
 /// Returns a parser which always ignores its input and produces a constant value.
 ///

--- a/Madness/Map.swift
+++ b/Madness/Map.swift
@@ -40,13 +40,11 @@ public func pure<C: CollectionType, T>(value: T) -> Parser<C, T>.Function {
 /// Flat map operator.
 infix operator >>- {
 	associativity left
-	precedence 150
+	precedence 100
 }
 
 /// Map operator.
 infix operator <^> {
 	associativity left
-
-	// Higher precedence than `>>-`.
-	precedence 155
+	precedence 130
 }

--- a/Madness/Reduction.swift
+++ b/Madness/Reduction.swift
@@ -1,15 +1,6 @@
 //  Copyright (c) 2015 Rob Rix. All rights reserved.
 
 /// Returns a parser which maps parse trees into another type.
-public func --> <C: CollectionType, T, U>(parser: Parser<C, T>.Function, f: T -> U) -> Parser<C, U>.Function {
-	return {
-		parser($0).map { (f($0), $1) }
-	}
-}
-
-/// Returns a parser which maps parse trees into another type.
-///
-/// This overload also receives the index that parsing ended at.
 public func --> <C: CollectionType, T, U>(parser: Parser<C, T>.Function, f: (C, Range<C.Index>, T) -> U) -> Parser<C, U>.Function {
 	return { input, index in
 		parser(input, index).map { (f(input, index..<$1, $0), $1) }

--- a/MadnessTests/AlternationTests.swift
+++ b/MadnessTests/AlternationTests.swift
@@ -83,10 +83,10 @@ final class AlternationTests: XCTestCase {
 
 private let alternation = %"x" | (%"y" --> { _, _, _ in 1 })
 
-private let optional = (%"y")|? --> { $0 ?? "" }
-private let prefixed = %"x" ++ optional --> { $0 + $1 }
-private let suffixed = optional ++ %"z" --> { $0 + $1 }
-private let sandwiched = prefixed ++ %"z" --> { $0 + $1 }
+private let optional = (%"y")|? |> map { $0 ?? "" }
+private let prefixed = %"x" ++ optional |> map { $0 + $1 }
+private let suffixed = optional ++ %"z" |> map { $0 + $1 }
+private let sandwiched = prefixed ++ %"z" |> map { $0 + $1 }
 
 private let one = oneOf(["x", "y", "z"])
 private let any = anyOf(["x", "y", "z"])

--- a/MadnessTests/CollectionTests.swift
+++ b/MadnessTests/CollectionTests.swift
@@ -8,9 +8,9 @@ final class CollectionTests: XCTestCase {
 
 		let fibonacci: (Int, Int) -> Fibonacci = fix { fibonacci in
 			{ (x: Int, y: Int) -> Fibonacci in
-				%(x + y) >>- { (xy: Int) -> Fibonacci in
+				(%(x + y) >>- { (xy: Int) -> Fibonacci in
 					fibonacci(y, xy) |> map { [ xy ] + $0 }
-				} | { ([], $1) }
+				}) | { ([], $1) }
 			}
 		}
 

--- a/MadnessTests/CollectionTests.swift
+++ b/MadnessTests/CollectionTests.swift
@@ -9,7 +9,7 @@ final class CollectionTests: XCTestCase {
 		let fibonacci: (Int, Int) -> Fibonacci = fix { fibonacci in
 			{ (x: Int, y: Int) -> Fibonacci in
 				%(x + y) >>- { (xy: Int) -> Fibonacci in
-					fibonacci(y, xy) --> { [ xy ] + $0 }
+					fibonacci(y, xy) |> map { [ xy ] + $0 }
 				} | { ([], $1) }
 			}
 		}

--- a/MadnessTests/MapTests.swift
+++ b/MadnessTests/MapTests.swift
@@ -83,6 +83,10 @@ final class MapTests: XCTestCase {
 		assertTree(parser, [2], ==, 12)
 	}
 
+	func testCurriedMap() {
+		assertTree(%123 |> map(toString), [123], ==, "123")
+	}
+
 
 	// MARK: pure
 

--- a/MadnessTests/MapTests.swift
+++ b/MadnessTests/MapTests.swift
@@ -68,6 +68,22 @@ final class MapTests: XCTestCase {
 	}
 
 
+	// MARK: map
+
+	func testMapTransformsParserOutput() {
+		assertTree(toString <^> %123, [123], ==, "123")
+	}
+
+	func testMapHasHigherPrecedenceThanFlatMap() {
+		let addTwo = { $0 + 2 }
+		let triple = { $0 * 3 }
+
+		let parser: Parser<[Int], Int>.Function = addTwo <^> %2 >>- { i in triple <^> pure(i) }
+
+		assertTree(parser, [2], ==, 12)
+	}
+
+
 	// MARK: pure
 
 	func testPureIgnoresItsInput() {

--- a/MadnessTests/MapTests.swift
+++ b/MadnessTests/MapTests.swift
@@ -25,7 +25,10 @@ private func == <T: Equatable> (left: Tree<T>, right: Tree<T>) -> Bool {
 	return left.values == right.values && left.children == right.children
 }
 
-final class FlatMapTests: XCTestCase {
+final class MapTests: XCTestCase {
+
+	// MARK: flatMap
+
 	func testFlatMap() {
 		let item = ignore("-") ++ %("a"..."z") ++ ignore("\n")
 		let tree: Int -> Parser<String, Tree<String>>.Function = fix { tree in
@@ -61,7 +64,11 @@ final class FlatMapTests: XCTestCase {
 		for input in failures {
 			XCTAssert(parse(tree(0), input) == nil)
 		}
+
 	}
+
+
+	// MARK: pure
 
 	func testPureIgnoresItsInput() {
 		assertTree(pure("a"), "b", ==, "a")

--- a/MadnessTests/MapTests.swift
+++ b/MadnessTests/MapTests.swift
@@ -35,7 +35,7 @@ final class MapTests: XCTestCase {
 			{ n in
 				let line: Parser<String, String>.Function = ignore(%"\t" * n) ++ item
 				return line >>- { itemContent in
-					(tree(n + 1)* --> { children in Tree(itemContent, children) })
+					(tree(n + 1)* |> map { children in Tree(itemContent, children) })
 				}
 			}
 		}

--- a/MadnessTests/ReductionTests.swift
+++ b/MadnessTests/ReductionTests.swift
@@ -1,7 +1,7 @@
 //  Copyright (c) 2015 Rob Rix. All rights reserved.
 
 final class ReductionTests: XCTestCase {
-	let reduction = %"x" --> { $0.uppercaseString }
+	let reduction = %"x" --> { $2.uppercaseString }
 
 	func testMapsParseTreesWithAFunction() {
 		assertTree(reduction, "x", ==, "X")
@@ -9,6 +9,15 @@ final class ReductionTests: XCTestCase {
 
 	func testRejectsInputRejectedByItsParser() {
 		assertUnmatched(reduction, "y")
+	}
+
+
+	enum Value { case Null }
+
+	let constReduction = %"null" --> { _ in Value.Null }
+
+	func testMapsConstFunctionOverInput() {
+		assertTree(constReduction, "null", ==, Value.Null)
 	}
 
 


### PR DESCRIPTION
Fixes #83.

I was mostly happy with this until I realised that this is the same thing as `-->`, and now there's three ways to do the same thing! As a result there's now both Reduction.swift and Map.swift, which seems a bit confusing given that `-->` is also map.

¯\\\_(ツ)\_/¯