### PR TITLE
Document oneOf(), anyOf() and allOf()

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,6 +57,24 @@ See `Madness.playground` for some examples of parsing with Madness.
 
 	parses `x`, and if it fails, `y`, and produces parses as `Either<X, Y>`. If `x` and `y` are of the same type, then it produces parses as `X`.
 
+	```swift
+	oneOf([x1, x2, x3])
+	```
+
+	tries a sequence of parsers until the first success, producing parses as `X`
+
+	```swift
+	anyOf(["x", "y", "z"])
+	```
+
+	tries to parse any of a set of literals in sequence, collecting each unique successful parse into an array until none match
+
+	```swift
+	allOf(["x", "y", "z"])
+	```
+
+	greedier than `anyOf`, parses every match from a set of literals in sequence, including duplicates
+
 - **Repetition**
 
 	```swift

--- a/README.md
+++ b/README.md
@@ -67,13 +67,13 @@ See `Madness.playground` for some examples of parsing with Madness.
 	anyOf(["x", "y", "z"])
 	```
 
-	tries to parse any of a set of literals in sequence, collecting each unique successful parse into an array until none match
+	tries to parse one each of a set of literals in sequence, collecting each successful parse into an array until none match
 
 	```swift
 	allOf(["x", "y", "z"])
 	```
 
-	greedier than `anyOf`, parses every match from a set of literals in sequence, including duplicates
+	greedier than `anyOf`, parsing every match from a set of literals in sequence, including duplicates
 
 - **Repetition**
 

--- a/README.md
+++ b/README.md
@@ -61,19 +61,19 @@ See `Madness.playground` for some examples of parsing with Madness.
 	oneOf([x1, x2, x3])
 	```
 
-	tries a sequence of parsers until the first success, producing parses as `X`
+	tries a sequence of parsers until the first success, producing parses as `X`.
 
 	```swift
 	anyOf(["x", "y", "z"])
 	```
 
-	tries to parse one each of a set of literals in sequence, collecting each successful parse into an array until none match
+	tries to parse one each of a set of literals in sequence, collecting each successful parse into an array until none match.
 
 	```swift
 	allOf(["x", "y", "z"])
 	```
 
-	greedier than `anyOf`, parsing every match from a set of literals in sequence, including duplicates
+	greedier than `anyOf`, parsing every match from a set of literals in sequence, including duplicates.
 
 - **Repetition**
 


### PR DESCRIPTION
Had a go at matching the style of the README, but found it kind of challenging to be both terse AND clear!

Fixes #84.