### PR TITLE
Add replace operator `<^`

### DIFF
--- a/Madness/Map.swift
+++ b/Madness/Map.swift
@@ -17,6 +17,11 @@ public func <^> <C: CollectionType, T, U> (f: T -> U, parser: Parser<C, T>.Funct
 	return parser >>- { pure(f($0)) }
 }
 
+/// Returns a parser which first parses `right`, replacing successful parses with `left`.
+public func <^ <C: CollectionType, T, U> (left: T, right: Parser<C, U>.Function) -> Parser<C, T>.Function {
+	return const(left) <^> right
+}
+
 /// Curried `<^>`. Returns a parser which applies `f` to transform the output of `parser`.
 public func map<C: CollectionType, T, U>(f: T -> U)(_ parser: Parser<C, T>.Function) -> Parser<C, U>.Function {
 	return f <^> parser
@@ -47,5 +52,12 @@ infix operator <^> {
 	precedence 130
 }
 
+/// Replace operator.
+infix operator <^ {
+	associativity left
+	precedence 130
+}
+
 
 import Either
+import Prelude

--- a/MadnessTests/MapTests.swift
+++ b/MadnessTests/MapTests.swift
@@ -25,6 +25,10 @@ private func == <T: Equatable> (left: Tree<T>, right: Tree<T>) -> Bool {
 	return left.values == right.values && left.children == right.children
 }
 
+private func == <T: Equatable, U: Equatable> (l: (T, U), r: (T, U)) -> Bool {
+	return l.0 == r.0 && l.1 == r.1
+}
+
 final class MapTests: XCTestCase {
 
 	// MARK: flatMap
@@ -81,6 +85,10 @@ final class MapTests: XCTestCase {
 		let parser: Parser<[Int], Int>.Function = addTwo <^> %2 >>- { i in triple <^> pure(i) }
 
 		assertTree(parser, [2], ==, 12)
+	}
+
+	func testReplaceConsumesItsInput() {
+		assertTree(("abc" <^ %123) ++ %0, [123, 0], ==, ("abc", 0))
 	}
 
 	func testCurriedMap() {


### PR DESCRIPTION
A combination of #91 and [this article](http://www.serpentine.com/blog/2008/02/06/the-basics-of-applicative-functors-put-to-practical-work/) gave me the inspiration for this.

Should be a useful operator to have around when writing parsers in an applicative style.