### PR TITLE
Count less

### DIFF
--- a/Madness/Parser.swift
+++ b/Madness/Parser.swift
@@ -29,7 +29,6 @@ public func none<C: CollectionType, Tree>(string: String = "no way forward") -> 
 
 /// Returns a parser which parses any single character.
 public func any<C: CollectionType>(input: C, index: C.Index) -> Parser<C, C.Generator.Element>.Result {
-
 	if input.count > 0 {
 		let parsed = input[index]
 		let next = index.successor()

--- a/Madness/Parser.swift
+++ b/Madness/Parser.swift
@@ -29,7 +29,7 @@ public func none<C: CollectionType, Tree>(string: String = "no way forward") -> 
 
 /// Returns a parser which parses any single character.
 public func any<C: CollectionType>(input: C, index: C.Index) -> Parser<C, C.Generator.Element>.Result {
-	if input.count > 0 {
+	if index != input.endIndex {
 		let parsed = input[index]
 		let next = index.successor()
 		


### PR DESCRIPTION
Avoid counting the input in `any`. It’s O(n) in forward and bidirectional collections, and we backtrack, which is O(n²), so, ouch.