### PR TITLE
Fix number parser

### DIFF
--- a/Madness.xcodeproj/project.pbxproj
+++ b/Madness.xcodeproj/project.pbxproj
@@ -8,6 +8,8 @@
 
 /* Begin PBXBuildFile section */
 		D1E153561BD5B78E00627E39 /* String.swift in Sources */ = {isa = PBXBuildFile; fileRef = D1E153551BD5B78E00627E39 /* String.swift */; settings = {ASSET_TAGS = (); }; };
+		B8E0AB871BF098DD002B5C8B /* StringTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B8E0AB861BF098DD002B5C8B /* StringTests.swift */; };
+		B8E0AB881BF098DD002B5C8B /* StringTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B8E0AB861BF098DD002B5C8B /* StringTests.swift */; };
 		D421A2A91A9A8E33009AC3B1 /* IgnoreTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D421A2A81A9A8E33009AC3B1 /* IgnoreTests.swift */; };
 		D421A2AA1A9A8E33009AC3B1 /* IgnoreTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D421A2A81A9A8E33009AC3B1 /* IgnoreTests.swift */; };
 		D421A2AC1A9A9540009AC3B1 /* ReductionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D421A2AB1A9A9540009AC3B1 /* ReductionTests.swift */; };
@@ -76,6 +78,7 @@
 /* End PBXContainerItemProxy section */
 
 /* Begin PBXFileReference section */
+		B8E0AB861BF098DD002B5C8B /* StringTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = StringTests.swift; sourceTree = "<group>"; };
 		D1E153551BD5B78E00627E39 /* String.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = String.swift; sourceTree = "<group>"; };
 		D421A2A81A9A8E33009AC3B1 /* IgnoreTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = IgnoreTests.swift; sourceTree = "<group>"; };
 		D421A2AB1A9A9540009AC3B1 /* ReductionTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = ReductionTests.swift; path = MadnessTests/ReductionTests.swift; sourceTree = SOURCE_ROOT; };
@@ -210,6 +213,7 @@
 				D421A2A81A9A8E33009AC3B1 /* IgnoreTests.swift */,
 				D421A2AB1A9A9540009AC3B1 /* ReductionTests.swift */,
 				D4C2EDB81A98D82200054FAA /* RepetitionTests.swift */,
+				B8E0AB861BF098DD002B5C8B /* StringTests.swift */,
 				D4C0FAFE1AC5ECCE00936032 /* Fixtures.swift */,
 				D4FC47C11A37E47C00D23A6F /* Supporting Files */,
 			);
@@ -417,6 +421,7 @@
 				D4C2EDBA1A98D82200054FAA /* RepetitionTests.swift in Sources */,
 				D490927B1A98F11A00275C79 /* CollectionTests.swift in Sources */,
 				D4C0FB011AC5EDA500936032 /* Fixtures.swift in Sources */,
+				B8E0AB881BF098DD002B5C8B /* StringTests.swift in Sources */,
 				D4BC5E131A98C97C008C6851 /* MapTests.swift in Sources */,
 				D4BC5E121A98C97C008C6851 /* ParserTests.swift in Sources */,
 				D4C2EDB21A98D5DB00054FAA /* AlternationTests.swift in Sources */,
@@ -449,6 +454,7 @@
 				D4C8B02E1A69B1A900943303 /* MapTests.swift in Sources */,
 				D490927A1A98F11A00275C79 /* CollectionTests.swift in Sources */,
 				D4C0FB021AC5EDA600936032 /* Fixtures.swift in Sources */,
+				B8E0AB871BF098DD002B5C8B /* StringTests.swift in Sources */,
 				D4C2EDB91A98D82200054FAA /* RepetitionTests.swift in Sources */,
 				D4FC47C41A37E47C00D23A6F /* ParserTests.swift in Sources */,
 				D4D328491A9AFE2700216D7E /* ErrorTests.swift in Sources */,

--- a/Madness/String.swift
+++ b/Madness/String.swift
@@ -39,16 +39,16 @@ public let int: CharacterArrayParser = {
 
 private let decimal: CharacterArrayParser = prepend <^> %"." <*> someDigits
 
-private let exp: StringParser = %"e" <|> %"e+" <|> %"e-" <|> %"E" <|> %"E+" <|> %"E-"
+private let exp: StringParser = %"e+" <|> %"e-" <|> %"e" <|> %"E+" <|> %"E-" <|> %"E"
 
 private let exponent: CharacterArrayParser = { s in { s.characters + $0 } } <^> exp <*> someDigits
 
 // Parses floating point numbers as doubles
 public let number: DoubleParser = { characters in Double(String(characters))! } <^>
-	(int
+	((concat2 <^> int <*> decimal <*> exponent)
 	<|> (concat <^> int <*> decimal)
 	<|> (concat <^> int <*> exponent)
-	<|> (concat2 <^> int <*> decimal <*> exponent))
+	<|> int)
 
 public let digit: CharacterParser = oneOf("0123456789")
 

--- a/MadnessTests/StringTests.swift
+++ b/MadnessTests/StringTests.swift
@@ -1,0 +1,61 @@
+//  Copyright (c) 2015 Rob Rix. All rights reserved.
+
+final class StringTests: XCTestCase {
+	func testSimpleIntegers() {
+		assertNumber("1")
+		assertNumber("45")
+		assertNumber("-13")
+	}
+
+	func testSimpleFloats() {
+		assertNumber("1.0")
+		assertNumber("45.3")
+		assertNumber("-2.53")
+	}
+
+	func testIntegerUnsignedExponents() {
+		assertNumber("2E1")
+		assertNumber("1e2")
+		assertNumber("0e3")
+		assertNumber("-1e4")
+		assertNumber("-2E5")
+		assertNumber("1e21")
+	}
+
+	func testIntegerSignedExponents() {
+		assertNumber("8e+1")
+		assertNumber("7e-2")
+		assertNumber("6E+3")
+		assertNumber("5E-4")
+		assertNumber("-4e+5")
+		assertNumber("-3e-6")
+		assertNumber("-2E+7")
+		assertNumber("-1E-8")
+	}
+
+	func testFloatUnsignedExponents() {
+		assertNumber("1.2e1")
+		assertNumber("4.567E2")
+		assertNumber("1.0e4")
+		assertNumber("-6.21e3")
+		assertNumber("-1.5E2")
+	}
+
+	func testFloatSignedExponents() {
+		assertNumber("1.4e+5")
+		assertNumber("2.5e-6")
+		assertNumber("3.6E+7")
+		assertNumber("4.7E-8")
+		assertNumber("-5.8E-9")
+	}
+}
+
+func assertNumber(input: String, message: String = "", file: String = __FILE__, line: UInt = __LINE__) -> Double? {
+	return assertEqual(parse(number, input: input).right, Double(input)!, message, file, line)
+}
+
+// MARK: - Imports
+
+import Assertions
+import Madness
+import XCTest


### PR DESCRIPTION
The number parsing was having trouble with greedy matching (int matched before decimals, decimals before decimals with exponents, and “e” before “e+”). This fixes all that and adds a slew of tests.